### PR TITLE
Make discord intents handling backward-compatible and update dev dependencies

### DIFF
--- a/markovbot/core.py
+++ b/markovbot/core.py
@@ -1,6 +1,7 @@
 import logging
 
-from discord import Guild, Game, Intents
+import discord
+from discord import Guild, Game
 from discord.ext.commands import Bot
 
 from markovbot.supervisor import Supervisor
@@ -16,10 +17,16 @@ class MarkovBot(Bot):
     overrides events for custom logic and handling.
     """
     def __init__(self):
-        intents = Intents.default()
-        intents.message_content = True
+        intents = None
+        if hasattr(discord, "Intents"):
+            intents = discord.Intents.default()
+            if hasattr(intents, "message_content"):
+                intents.message_content = True
 
-        super().__init__(command_prefix='!markov ', description=description, intents=intents)
+        if intents is None:
+            super().__init__(command_prefix='!markov ', description=description)
+        else:
+            super().__init__(command_prefix='!markov ', description=description, intents=intents)
 
         self.supervisor = Supervisor()
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,10 +1,9 @@
 -r base.txt
-astroid==2.4.2
-isort==4.3.21
-lazy-object-proxy==1.5.*
-mccabe==0.6.1
-pylint==2.5.3
-rope==0.11.0
-six==1.15.0
-typed-ast==1.4.1
-wrapt==1.12.1
+astroid==2.15.8
+isort==5.12.0
+lazy-object-proxy==1.9.0
+mccabe==0.7.0
+pylint==2.17.5
+rope==1.13.0
+six==1.16.0
+wrapt==1.15.0


### PR DESCRIPTION
### Motivation

- Tests were failing due to incompatible dev dependency versions that prevented a clean install on the current Python runtime.  
- The bot initialization assumed `discord.Intents` and the `message_content` attribute existed, causing import/attribute errors with different `discord.py` versions.  

### Description

- Updated development dependency pins in `requirements/dev.txt` to newer, Python 3.10-compatible versions (e.g., `astroid`, `isort`, `pylint`, `rope`, `six`, `wrapt`).  
- Modified `markovbot/core.py` to import the `discord` module and detect support for `Intents` at runtime.  
- Only set `intents.message_content = True` when the attribute exists, and call `super().__init__` with or without the `intents` argument depending on availability.  

### Testing

- Ran `pytest` and all tests passed (`6 passed, 31 warnings`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961b0d16c0c832aa03cc9a1c1ebaad7)