### PR TITLE
Remove Azure deployment and update Actions versions in CI workflow

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python 3.14
       uses: actions/setup-python@v5
       with:
@@ -33,51 +33,13 @@ jobs:
     needs: [test]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Build the Docker image
       run: docker build . --file Dockerfile --tag sheldonburks/discord-markov-bot:latest
     
-    - uses: actions/checkout@master
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: sheldonburks/discord-markov-bot
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
-  
-  deploy-container:
-    name: Deploy Container
-    runs-on: ubuntu-latest
-    needs: [test, build-and-publish-docker-image]
-
-    steps:
-    - name: 'Login via Azure CLI'
-      uses: azure/login@v1
-      with:
-        creds: ${{ secrets.AZURE_CREDENTIALS }}
-    
-    - name: Deploy Image to Azure Container Instances
-      uses: Azure/aci-deploy@v1
-      with:
-        resource-group: discord-markov-bot
-        image: sheldonburks/discord-markov-bot:latest
-        name: discord-markov-bot
-        dns-name-label: 'discord-markov-bot'
-        cpu: 1
-        memory: 1
-        location: 'east us'
-        registry-login-server: index.docker.io
-        registry-username: ${{ secrets.DOCKER_USERNAME }}
-        registry-password: ${{ secrets.DOCKER_PASSWORD }}
-        environment-variables: DB_PATH=/mnt/db/
-        secure-environment-variables: DISCORD_BOT_TOKEN=${{ secrets.DISCORD_BOT_TOKEN }}
-        azure-file-volume-account-key: ${{ secrets.AZURE_FILE_VOLUME_ACCOUNT_KEY }}
-        azure-file-volume-account-name: ${{ secrets.AZURE_FILE_VOLUME_ACCOUNT_NAME }}
-        azure-file-volume-mount-path: /mnt/db/
-        azure-file-volume-share-name: discord-markov-bot
-
-    - name: Restart Container Group
-      uses: azure/CLI@v1
-      with:
-        inlineScript: |
-          az container restart --resource-group Discord-Markov-Bot --name discord-markov-bot 


### PR DESCRIPTION
### Motivation
- Stop running the Azure container deployment from the CI workflow to remove unused/legacy deployment steps.
- Bring action references up to supported versions to avoid deprecated usage and security advisories.
- Simplify the build workflow to only run tests and publish the Docker image.

### Description
- Replace `actions/checkout@v2` with `actions/checkout@v4` in the `test` and `build-and-publish-docker-image` jobs.
- Update `elgohr/Publish-Docker-Github-Action` from `@master` to `@v5` for Docker publishing.
- Remove the `deploy-container` job and all Azure-related steps that used `azure/login@v1`, `Azure/aci-deploy@v1`, and `azure/CLI@v1`.

### Testing
- No automated CI jobs were executed because this change only modifies the workflow file.
- No unit tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961ba366f80832ab2770be079d2d2b7)