### PR TITLE
Add unit tests for MarkovBot guild events and presence update

### DIFF
--- a/test/test_core.py
+++ b/test/test_core.py
@@ -1,0 +1,81 @@
+import asyncio
+import unittest
+from unittest.mock import AsyncMock, patch
+
+from discord import Game
+
+from markovbot.core import MarkovBot
+from .utils import get_guild
+
+
+class MarkovBotTest(unittest.TestCase):
+
+    def test_on_guild_join_adds_and_updates_presence(self):
+        with patch("markovbot.core.Supervisor") as supervisor_factory:
+            supervisor = supervisor_factory.return_value
+            bot = MarkovBot()
+            bot.update_presence = AsyncMock()
+
+            guild = get_guild()
+
+            asyncio.run(bot.on_guild_join(guild))
+
+            supervisor.add.assert_awaited_once_with(guild)
+            bot.update_presence.assert_awaited_once()
+
+    def test_on_guild_remove_removes_and_updates_presence(self):
+        with patch("markovbot.core.Supervisor") as supervisor_factory:
+            supervisor = supervisor_factory.return_value
+            bot = MarkovBot()
+            bot.update_presence = AsyncMock()
+
+            guild = get_guild()
+
+            asyncio.run(bot.on_guild_remove(guild))
+
+            supervisor.remove.assert_called_once_with(guild)
+            bot.update_presence.assert_awaited_once()
+
+    def test_on_guild_available_adds_and_updates_presence(self):
+        with patch("markovbot.core.Supervisor") as supervisor_factory:
+            supervisor = supervisor_factory.return_value
+            bot = MarkovBot()
+            bot.update_presence = AsyncMock()
+
+            guild = get_guild()
+
+            asyncio.run(bot.on_guild_available(guild))
+
+            supervisor.add.assert_awaited_once_with(guild)
+            bot.update_presence.assert_awaited_once()
+
+    def test_on_guild_unavailable_removes_with_delete_and_updates_presence(self):
+        with patch("markovbot.core.Supervisor") as supervisor_factory:
+            supervisor = supervisor_factory.return_value
+            bot = MarkovBot()
+            bot.update_presence = AsyncMock()
+
+            guild = get_guild()
+
+            asyncio.run(bot.on_guild_unavailable(guild))
+
+            supervisor.remove.assert_called_once_with(guild, True)
+            bot.update_presence.assert_awaited_once()
+
+    def test_update_presence_sets_game_activity_from_supervisor_count(self):
+        with patch("markovbot.core.Supervisor") as supervisor_factory:
+            supervisor = supervisor_factory.return_value
+            supervisor.connected_guild_count.return_value = 3
+            bot = MarkovBot()
+            bot.change_presence = AsyncMock()
+
+            asyncio.run(bot.update_presence())
+
+            bot.change_presence.assert_awaited_once()
+            activity = bot.change_presence.call_args.kwargs["activity"]
+            self.assertIsInstance(activity, Game)
+            self.assertEqual(activity.name, "on 3 servers.")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### Motivation

- Add unit tests to validate that `MarkovBot` event handlers notify the `Supervisor` and refresh bot presence as expected.
- Verify that `update_presence` composes the correct `Game` activity string from the supervisor's connected guild count.
- Keep async test execution consistent with existing tests by using `asyncio.run`.

### Description

- Add `test/test_core.py` containing tests for `on_guild_join`, `on_guild_remove`, `on_guild_available`, `on_guild_unavailable`, and `update_presence`.
- Patch `markovbot.core.Supervisor` and use `AsyncMock` to stub `update_presence` and `change_presence` calls in tests.
- Assert that `Supervisor.add`/`Supervisor.remove` are called with the correct arguments and that presence updates are awaited.
- Test `update_presence` by setting `supervisor.connected_guild_count.return_value = 3` and asserting the `Game` activity name is `on 3 servers.`

### Testing

- No automated tests were executed as part of this change.
- The new tests are implemented with `unittest` and can be run with `python -m unittest`.
- Tests use `asyncio.run` and `unittest.mock.AsyncMock` and are expected to pass in a proper test environment with the `discord` types available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961beb93388832a94592889290c590e)