### PR TITLE
Add AGENTS.md with architecture overview and test guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,14 @@
+# Agent Guidelines
+
+## Architecture Overview
+- **Entrypoint:** `bot.py` initializes logging, loads `DISCORD_BOT_TOKEN`, and runs the Discord bot via `markovbot.run(...)`.
+- **Bot core:** `markovbot/core.py` defines `MarkovBot`, a `discord.ext.commands.Bot` subclass that manages lifecycle events and presence updates while delegating guild management to `Supervisor`.
+- **Commands:** `markovbot/commands.py` registers the `say` and `learn` commands that generate sentences or rebuild the Markov chain.
+- **Supervisor & seeding:** `markovbot/supervisor.py` tracks connected guilds and kicks off seeding. `markovbot/seeder.py` downloads channel history, filters messages, and rebuilds chains.
+- **Markov model:** `markovbot/markov.py` defines a `CustomMarkovText` wrapper around `markovify` and generates sentences from persisted chains.
+- **Persistence:** `markovbot/persistence.py` stores Markov chains in TinyDB (`markov_db.json`), keyed by guild ID.
+- **Tests:** `test/` contains unittest-based coverage for persistence and supervisor behavior.
+
+## Agent Instructions
+- When you make a change, **always run the tests and ensure they pass** before finalizing your work.
+  - Suggested command: `python -m unittest`


### PR DESCRIPTION
### Motivation
- Provide a single-file architecture overview to help contributors understand the project layout and responsibilities.
- Give explicit agent workflow guidance so changes are made consistently and safely.
- Emphasize running the test suite as a required step before finalizing changes.

### Description
- Added `AGENTS.md` containing an architecture summary covering `bot.py`, `markovbot/core.py`, `markovbot/commands.py`, `markovbot/supervisor.py`, `markovbot/seeder.py`, `markovbot/markov.py`, and `markovbot/persistence.py`.
- Documented where Markov chains are persisted and which components handle seeding, command handling, and presence updates.
- Added a clear agent instruction to run the test suite using `python -m unittest` and ensure tests pass before finishing work.

### Testing
- Ran the automated test suite with `python -m unittest` as instructed in the new guidance.
- The test run failed with `ModuleNotFoundError: No module named 'discord'` while importing `markovbot`.
- The test run reported 3 tests encountered errors (tests did not succeed due to the missing dependency).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961d42b5788832a8f5838cb7730eb8a)