### PR TITLE
Remove supervisor tests for persistence and logging

### DIFF
--- a/test/test_supervisor.py
+++ b/test/test_supervisor.py
@@ -1,6 +1,5 @@
 import asyncio
 import unittest
-from unittest import mock
 
 from markovbot.supervisor import Supervisor
 from .utils import get_guild

--- a/test/test_supervisor.py
+++ b/test/test_supervisor.py
@@ -1,5 +1,6 @@
-import unittest
 import asyncio
+import unittest
+from unittest import mock
 
 from markovbot.supervisor import Supervisor
 from .utils import get_guild
@@ -25,6 +26,20 @@ class SupervisorTest(unittest.TestCase):
         supervisor.remove(guild)
 
         self.assertNotIn(guild.id, supervisor.guilds)
+
+    def test_connected_guild_count_after_add_remove(self):
+        supervisor = Supervisor()
+        guild = get_guild()
+
+        self.assertEqual(supervisor.connected_guild_count(), 0)
+
+        asyncio.run(supervisor.add(guild))
+
+        self.assertEqual(supervisor.connected_guild_count(), 1)
+
+        supervisor.remove(guild)
+
+        self.assertEqual(supervisor.connected_guild_count(), 0)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Motivation
- Two tests were mocking external behavior (`persistence.delete_chain` and `log.warning`) which are not core responsibilities of the `Supervisor` unit tests.
- Remove noisy tests that assert side-effects on external modules instead of verifying `Supervisor` state.
- Keep the test suite focused on `Supervisor` behavior (adding/removing guilds and connection counts).

### Description
- Deleted `test_remove_delete_data_calls_delete_chain` and `test_remove_missing_guild_logs_warning` from `test/test_supervisor.py`.
- Retained `test_can_add_guild`, `test_can_remove_guild`, and `test_connected_guild_count_after_add_remove` to verify core `Supervisor` state changes.
- Removed tests that patched `markovbot.supervisor.persistence.delete_chain` and `markovbot.supervisor.log.warning` to avoid testing external side-effects.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961bebe3020832a899b6a37e2ed5224)